### PR TITLE
fix: 💚 Repair broken Meeting Reminder Action - check date job

### DIFF
--- a/.github/workflows/meeting-reminder.yaml
+++ b/.github/workflows/meeting-reminder.yaml
@@ -14,7 +14,7 @@ jobs:
           next_date=$(date -d "next Monday" "+%d.%m.")
           echo "next_date=$next_date" >> "$GITHUB_OUTPUT"
           next_date_day=$(date -d "next Monday" "+%d")
-          if (( next_date_day < 16 || 23 < next_date_day ));
+          if [[ 10#$next_date_day < 16 ]] || [[ 23 < 10#$next_date_day ]];
           then
             echo "::notice::Wrong week, skip sending reminder."
             exit 1


### PR DESCRIPTION
Das sollte den Fehler https://github.com/FreifunkMD/.github/actions/runs/4877936396/jobs/8703096933#step:2:12 beheben.