### PR TITLE
Prevent error messages when there is no meeting

### DIFF
--- a/.github/workflows/meeting-reminder.yaml
+++ b/.github/workflows/meeting-reminder.yaml
@@ -21,6 +21,7 @@ jobs:
             echo "::notice::Wrong week, skip sending reminder."
             exit 1
           fi
+        continue-on-error: true
     outputs:
       next_date: ${{ steps.date.outputs.next_date }}
   


### PR DESCRIPTION
Adds the continue-on-error key to the date step in the workflow. This prevents the workflow from failing when there's no meeting.

The discord and email jobs will still run, but they will not send out reminders because the next_date output will not be set.