### PR TITLE
Revert changes to the reminder workflow

### DIFF
--- a/.github/workflows/meeting-reminder.yaml
+++ b/.github/workflows/meeting-reminder.yaml
@@ -2,7 +2,7 @@ name: Send out reminder about monthly meeting
 
 on:
   schedule:
-    - cron: '0 1 8-14 * THU'
+    - cron: '1 0 * * THU'
   workflow_dispatch:
 
 
@@ -15,6 +15,13 @@ jobs:
         run: |
           next_date=$(date -d "next Monday" "+%d.%m.")
           echo "next_date=$next_date" >> "$GITHUB_OUTPUT"
+          next_date_day=$(date -d "next Monday" "+%d")
+          if [[ $next_date_day < 15 ]] || [[ $next_date_day > 21 ]];
+          then
+            echo "::notice::Wrong week, skip sending reminder."
+            exit 1
+          fi
+        continue-on-error: true
     outputs:
       next_date: ${{ steps.date.outputs.next_date }}
   

--- a/.github/workflows/meeting-reminder.yaml
+++ b/.github/workflows/meeting-reminder.yaml
@@ -21,7 +21,6 @@ jobs:
             echo "::notice::Wrong week, skip sending reminder."
             exit 1
           fi
-        continue-on-error: true
     outputs:
       next_date: ${{ steps.date.outputs.next_date }}
   

--- a/.github/workflows/meeting-reminder.yaml
+++ b/.github/workflows/meeting-reminder.yaml
@@ -1,6 +1,8 @@
 name: Send out reminder about monthly meeting
 
 on:
+  # Be careful when changing the schedule:
+  # CRON uses _or_ when day-of-month and day-of-week are provided.
   schedule:
     - cron: '1 0 * * THU'
   workflow_dispatch:


### PR DESCRIPTION
The last two PRs (#42, #43) made things worse, so revert them for now.

This should prevent false invitations, but brings back the workflow fail in weeks without a meeting.